### PR TITLE
ローカル環境でRails testが動作しない問題を修正

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -58,8 +58,10 @@ development:
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
-  <<: *default
-  database: workspace_test
+  adapter: sqlite3
+  database: db/development.sqlite3
+  pool: 5
+  timeout: 5000
 
 # As with config/secrets.yml, you never want to store sensitive information,
 # like your database password, in your source code. If your source code is


### PR DESCRIPTION
test環境のデータベースがpgになっていてpgをインストしていないローカル環境で無事死亡する問題を修正。